### PR TITLE
ci: add Homebrew formula audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Audit
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  Audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Homebrew/actions/setup-homebrew@master
+      - name: Tap this repository
+        run: |
+          mkdir -p $(brew --repository)/Library/Taps/clouatre-labs
+          ln -s $GITHUB_WORKSPACE $(brew --repository)/Library/Taps/clouatre-labs/homebrew-tap
+      - name: Audit formulae
+        run: brew audit --strict --online --tap clouatre-labs/tap


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow that runs `brew audit --strict --online` on pull requests to main branch.

## Changes

- Add `.github/workflows/audit.yml` with:
  - Trigger on `pull_request` to main
  - Uses `Homebrew/actions/setup-homebrew@master`
  - Runs `brew audit --strict --online Formula/*.rb`
  - Job name: `Audit` (for ruleset status check)

## Next Steps

After this PR merges:
1. Create branch ruleset with `Audit` as required status check
2. Verify aptu#146 is merged (PR-based Homebrew updates)

## Related

- Part of #1
- Blocked by: clouatre-labs/aptu#146