### PR TITLE
fix: remove v prefix from version field

### DIFF
--- a/Formula/aptu.rb
+++ b/Formula/aptu.rb
@@ -1,7 +1,7 @@
 class Aptu < Formula
   desc "Gamified OSS issue triage with AI assistance"
   homepage "https://github.com/clouatre-labs/aptu"
-  version "v0.1.2"
+  version "0.1.2"
   license "Apache-2.0"
   
   if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
## Summary

Remove the `v` prefix from the version field to fix `brew upgrade` detection.

## Problem

Homebrew compares versions as strings. The formula had `version "v0.1.2"` but users had `0.1.1` installed. Homebrew did not recognize `v0.1.2` as newer than `0.1.1`.

## Fix

```ruby
# Before
version "v0.1.2"

# After
version "0.1.2"
```

Fixes clouatre-labs/aptu#183