### PR TITLE
Update aptu and aptu-mcp formulas for v0.4.1

### DIFF
--- a/Formula/aptu-mcp.rb
+++ b/Formula/aptu-mcp.rb
@@ -5,13 +5,13 @@ class AptuMcp < Formula
   
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-mcp-0.4.1-aarch64-apple-darwin.tar.gz"
-    sha256 "595ba022224b59e38dad7e5e718817b253cd1089f035d776de33ad42075dcd10"
+    sha256 "ce234e9ec421056f0d683cd6bd9088118d05d68cfdd638f01c46694430f21483"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-mcp-0.4.1-aarch64-unknown-linux-musl.tar.gz"
-    sha256 "85f232466cb49eda3f9a5caeaaafeac5e3867a7f0f15a86346588868904172f2"
+    sha256 "8c55ba452bbdae8db4e2942520f678066adfe5507a19f8ea7ae1ac0bbf02a424"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-mcp-0.4.1-x86_64-unknown-linux-musl.tar.gz"
-    sha256 "c30e94123f3eba096016dd7c639811a8c0f526d30a8c60e50c68a691b16c3029"
+    sha256 "de9dd1055f52f832c6e1d042666a9ef33c56aaca02ac96fac9389bd16dac24ed"
   end
   
   def install

--- a/Formula/aptu.rb
+++ b/Formula/aptu.rb
@@ -5,13 +5,13 @@ class Aptu < Formula
   
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-cli-0.4.1-aarch64-apple-darwin.tar.gz"
-    sha256 "0c5be07b9bfcd5f39e92ca747564a9bc093ca64d4d9fb6a359171e3acb77bd9c"
+    sha256 "b260819431110437ff15ee257fbb0ed8ffba3fe221da9204288739d31c6a5730"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-cli-0.4.1-aarch64-unknown-linux-musl.tar.gz"
-    sha256 "d958966a3436326dfeba63893028f3c788c5caeda5c760d81d947ecefccf809b"
+    sha256 "a8df02fac3e25b003c47303823742b8704af4f3c0163df7e354bc420f35d411e"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/clouatre-labs/aptu/releases/download/v0.4.1/aptu-cli-0.4.1-x86_64-unknown-linux-musl.tar.gz"
-    sha256 "e169c30af548faa9e6225b407f8183a584ce09fc1aa66038c9b4d5a8032fa0a0"
+    sha256 "217aaeb0ac223a1fb912c5d3097dafef84872ed9426077f455511208d2a16898"
   end
   
   def install


### PR DESCRIPTION
Automated formula update with SHA256 checksums for release v0.4.1