### PR TITLE
Update code-analyze-mcp formula for v0.6.0

### DIFF
--- a/Formula/code-analyze-mcp.rb
+++ b/Formula/code-analyze-mcp.rb
@@ -4,14 +4,14 @@ class CodeAnalyzeMcp < Formula
   license "Apache-2.0"
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.5.0/code-analyze-mcp-0.5.0-aarch64-apple-darwin.tar.gz"
-    sha256 "529316480fb32e8a0ad2bcdddacfe6d8e543bbff89669638122a1ce66114cb62"
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.6.0/code-analyze-mcp-0.6.0-aarch64-apple-darwin.tar.gz"
+    sha256 "f6fa88ee86e28f8e97e5d2c39589693cc11f7f1c497868c0ec4794728436ef49"
   elsif OS.linux? && Hardware::CPU.arm?
-    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.5.0/code-analyze-mcp-0.5.0-aarch64-unknown-linux-musl.tar.gz"
-    sha256 "18a5179536ebcd4995889d445824a0958f7a7a2925db6b92bcc04e693af119c3"
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.6.0/code-analyze-mcp-0.6.0-aarch64-unknown-linux-musl.tar.gz"
+    sha256 "ec2d25bfe0279bcadd2c7ab0452b787afb3c5293373e2be4cc65791b535d9fc9"
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.5.0/code-analyze-mcp-0.5.0-x86_64-unknown-linux-musl.tar.gz"
-    sha256 "afdd460812ae9558552199b1c659705644a67069740123500d00154f542941fe"
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.6.0/code-analyze-mcp-0.6.0-x86_64-unknown-linux-musl.tar.gz"
+    sha256 "f1efc2a2ea363a068357234cf141b8cb339c6e6dda8b34fb1fabc0374f81660b"
   end
 
   def install


### PR DESCRIPTION
Automated formula update with SHA256 checksums for release v0.6.0