### PR TITLE
feat(aptu-coder): add service block for brew services start on port 49200

### DIFF
--- a/Formula/aptu-coder.rb
+++ b/Formula/aptu-coder.rb
@@ -18,6 +18,14 @@ class AptuCoder < Formula
     bin.install "aptu-coder"
   end
 
+  service do
+    run [opt_bin/"aptu-coder", "--port", "49200"]
+    keep_alive true
+    log_path var/"log/aptu-coder.log"
+    error_log_path var/"log/aptu-coder.log"
+    environment_variables PATH: std_service_path_env
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/aptu-coder --version")
   end


### PR DESCRIPTION
## Summary

Adds a `service` block to the `aptu-coder` formula so the server can be started and kept alive as a background service via `brew services`.

Companion to clouatre-labs/aptu-coder#888 (`APTU_CODER_PORT` env var support).

## Why

Streamable HTTP is the preferred transport when multiple clients need to share a single server instance (e.g. an orchestrator and its delegates, or two separate MCP clients on the same machine). With stdio, each client spawns its own isolated process. With a persistent HTTP service, all clients connect to the same process.

The `service` block makes this a one-time setup:

```bash
brew install clouatre-labs/tap/aptu-coder
brew services start aptu-coder
```

The server then runs at `http://127.0.0.1:49200/mcp` on login, restarted automatically on crash. Any MCP client that supports streamable HTTP can connect:

```
http://127.0.0.1:49200/mcp
```

## Security

Binds to `127.0.0.1` only (loopback). Not reachable from the network. Consistent with MCP spec guidance for local HTTP servers.

## Changes

- `Formula/aptu-coder.rb` -- `service` block: `run` with `--port 49200`, `keep_alive true`, `log_path`, `error_log_path`, `environment_variables PATH: std_service_path_env`

## Test plan

- [ ] `brew style Formula/aptu-coder.rb` clean
- [ ] `brew audit --strict Formula/aptu-coder.rb` clean
- [ ] `brew services start aptu-coder` starts server; `curl http://127.0.0.1:49200/mcp` responds
- [ ] `brew services stop aptu-coder` stops the server cleanly
