### PR TITLE
chore(deps): add non-major automerge rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
   "timezone": "UTC",
   "packageRules": [
     {
+      "groupName": "non-major",
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
+      "automerge": true
+    },
+    {
       "groupName": "github-actions",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],


### PR DESCRIPTION
## Summary

Adds a `non-major` packageRule with automerge for patch, minor, digest, pin, and lockFileMaintenance updates. Previously only github-actions updates were automerged; regular dependencies had no automerge rule.

Aligns with the pattern used in aptu and other clouatre-labs repos.

## Changes

- `.github/renovate.json`: add `non-major` packageRule
