### PR TITLE
feat(formula): add service do block to aptu-coder formula

### DIFF
--- a/Formula/aptu-coder.rb
+++ b/Formula/aptu-coder.rb
@@ -14,6 +14,13 @@ class AptuCoder < Formula
     sha256 "8c7c71550bfc7991dcd5584c46e2b23a33adb4575322f2e0adf2fe47fec1fe0d"
   end
 
+  service do
+    run [opt_bin/"aptu-coder", "--port", "49200"]
+    keep_alive true
+    log_path var/"log/aptu-coder.log"
+    error_log_path var/"log/aptu-coder.log"
+  end
+
   def install
     bin.install "aptu-coder"
   end


### PR DESCRIPTION
## Summary

Adds a `service do` block to the `aptu-coder` Homebrew formula so that `brew services start aptu-coder` starts the HTTP server on port 49200. Without this block the command had no effect, leaving users to write a LaunchAgent plist manually.

## Changes

- `Formula/aptu-coder.rb`: added `service do` block with `run`, `keep_alive`, `log_path`, and `error_log_path`

## Test plan

- [ ] `brew services start aptu-coder` starts the server on port 49200 after a clean `brew install`
- [ ] `brew services stop aptu-coder` stops the server cleanly
- [ ] `brew audit --strict aptu-coder` passes (verified locally: no output)
- [ ] `brew style Formula/aptu-coder.rb` passes (verified locally: no offenses)

Closes #912
