### PR TITLE
fix(formula): restore service do block dropped by automated bump

### DIFF
--- a/Formula/aptu-coder.rb
+++ b/Formula/aptu-coder.rb
@@ -14,6 +14,13 @@ class AptuCoder < Formula
     sha256 "d6d793a44bcfddeb033885185cafbac18c017a72cd0f141942e961ac7fd7758d"
   end
 
+  service do
+    run [opt_bin/"aptu-coder", "--port", "49200"]
+    keep_alive true
+    log_path var/"log/aptu-coder.log"
+    error_log_path var/"log/aptu-coder.log"
+  end
+
   def install
     bin.install "aptu-coder"
   end


### PR DESCRIPTION
## Summary

Restores the `service do` block that was dropped by the automated formula bump in #103. The block was added in #102 but the Renovate-style bump overwrote the formula without carrying it forward.

## Changes

- `Formula/aptu-coder.rb`: restore `service do` block (run, keep_alive, log_path, error_log_path)

## Test plan

- [ ] `brew audit --strict` clean
- [ ] `brew style` no offenses
- [ ] `brew services start aptu-coder` starts the server on port 49200
