### PR TITLE
fix(formula): disable auto-start; clarify stdio-first usage

### DIFF
--- a/Formula/aptu-coder.rb
+++ b/Formula/aptu-coder.rb
@@ -16,9 +16,21 @@ class AptuCoder < Formula
 
   service do
     run [opt_bin/"aptu-coder", "--port", "49200"]
-    keep_alive true
+    keep_alive false
     log_path var/"log/aptu-coder.log"
     error_log_path var/"log/aptu-coder.log"
+  end
+
+  def caveats
+    <<~EOS
+      aptu-coder defaults to stdio mode: your MCP client (e.g. Claude, goose)
+      launches and manages the process directly. This is the recommended mode
+      for single-client use and requires no background service.
+
+      To share a single server instance across multiple MCP clients, run it as
+      a persistent HTTP service on port 49200:
+        brew services start clouatre-labs/tap/aptu-coder
+    EOS
   end
 
   def install


### PR DESCRIPTION
## Summary

Set `keep_alive false` in the service block and add a `caveats` method
that explains stdio-first usage.

The original `keep_alive true` caused two problems:

- Homebrew auto-registered a launchd daemon on install, starting a background HTTP process most users never need
- The auto-generated caveat was contradictory: it told users to restart the service while simultaneously suggesting they might not need one

aptu-coder's primary transport is stdio, launched on demand by the MCP client. The HTTP listener (`--port 49200`) is a secondary, opt-in mode for users who explicitly want a persistent service.

## Changes

`Formula/aptu-coder.rb`:

- `keep_alive true` -> `keep_alive false`: service is registered with launchd but not auto-started on install
- Add `caveats` method explaining stdio is the default and documenting `brew services start` as the opt-in path for HTTP mode

## After this change

Users will see on install/upgrade:

```
==> Caveats
aptu-coder runs in stdio mode by default and is launched directly by
your MCP client (e.g. Claude, goose). No background service is needed
for normal use.

To run as a persistent HTTP service on port 49200 (opt-in):
  brew services start clouatre-labs/tap/aptu-coder
```

`brew services start/stop/restart` continue to work for users who opt in.
The restart caveat on upgrade only appears if the user previously started the service, which is the correct context for it.

## Test plan

- [ ] `brew install clouatre-labs/tap/aptu-coder` shows the new caveat, no service auto-start
- [ ] `brew upgrade clouatre-labs/tap/aptu-coder` does not show the restart caveat unless the service was previously started
- [ ] `brew services start clouatre-labs/tap/aptu-coder` works for users who want HTTP mode
