### PR TITLE
chore(deps): bump aptu action to v0.8.6

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -28,7 +28,7 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
-          model: gemini-3.1-flash-lite-preview
+          model: gemini-3.1-flash-lite
           skip-labeled: 'false'
           fallback-provider: 'openrouter'
           fallback-model: 'inception/mercury-2'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@b505a0c3144c113c77f1607025c0cc7f60c654d6 # v0.8.4
+        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump `clouatre-labs/aptu` reusable workflow to v0.8.6.

SHA: `93ca6d6613ebc2bb47f92caf48d10509ad0920e3`

Changelog: https://github.com/clouatre-labs/aptu/releases/tag/v0.8.6
